### PR TITLE
Fix AmsiScanBuffer call

### DIFF
--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -27,7 +27,7 @@ namespace AMSI
         [DllImport("Amsi.dll", EntryPoint = "AmsiScanString", CallingConvention = CallingConvention.StdCall)]
         public static extern int AmsiScanString(IntPtr amsiContext, [InAttribute()] [MarshalAsAttribute(UnmanagedType.LPWStr)]string @string, [InAttribute()] [MarshalAsAttribute(UnmanagedType.LPWStr)]string contentName, IntPtr session, out AMSI_RESULT result);
         [DllImport("Amsi.dll", EntryPoint = "AmsiScanBuffer", CallingConvention = CallingConvention.StdCall)]
-        public static extern int AmsiScanBuffer(IntPtr amsiContext, byte[] buffer, ulong length, string contentName, IntPtr session, out AMSI_RESULT result);
+        public static extern int AmsiScanBuffer(IntPtr amsiContext, byte[] buffer, uint length, string contentName, IntPtr session, out AMSI_RESULT result);
         
         //This method apparently exists on MSDN but not in AMSI.dll (version 4.9.10586.0)
         [DllImport("Amsi.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]


### PR DESCRIPTION
ULONG in C is 4 bytes - whereas in C#, ulong is 8 bytes which was causing call to fail.
